### PR TITLE
fix: proper cleanup of dx11 antialiasing

### DIFF
--- a/impl/d3d11_manager.cpp
+++ b/impl/d3d11_manager.cpp
@@ -207,6 +207,7 @@ void d3d11_manager::draw() {
 		desc.ArraySize = 1;
 		desc.Format = rt_desc.Format;
 		desc.SampleDesc.Count = 1;
+		desc.SampleDesc.Quality = 0;
 		desc.Usage = D3D11_USAGE_DEFAULT;
 		desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
 		


### PR DESCRIPTION
DX11 uses the SampleDesc->Count and SampleDesc->Quality for antialiasing. Setting Count to 1 and Quality to 0 disables the dx11 internal MSAA. Now antialiasing isn't enabled per default anymore.